### PR TITLE
feat: orders crud

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -36,6 +36,9 @@ gem 'blueprinter'
 gem 'rswag-api'
 gem 'rswag-ui'
 
+# Gem for state machine
+gem 'aasm'
+
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem
   gem "debug", platforms: %i[ mri windows ], require: "debug/prelude"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,8 @@
 GEM
   remote: https://rubygems.org/
   specs:
+    aasm (5.5.0)
+      concurrent-ruby (~> 1.0)
     actioncable (7.2.2.1)
       actionpack (= 7.2.2.1)
       activesupport (= 7.2.2.1)
@@ -316,6 +318,7 @@ PLATFORMS
   x86_64-linux-musl
 
 DEPENDENCIES
+  aasm
   blueprinter
   bootsnap
   brakeman

--- a/app/api/api_controller.rb
+++ b/app/api/api_controller.rb
@@ -14,4 +14,8 @@ class ApiController < ApplicationController
   rescue_from ActiveRecord::AssociationTypeMismatch do |e|
     render json: { error_code: 'invalid_params', description: e.message }, status: 422
   end
+
+  rescue_from AASM::InvalidTransition do |e|
+    render json: { error_code: 'invalid_transition', description: e.message }, status: 422
+  end
 end

--- a/app/api/v1/orders_controller.rb
+++ b/app/api/v1/orders_controller.rb
@@ -1,0 +1,51 @@
+module V1
+  class OrdersController < ApiController
+    before_action :set_order, only: [:update, :show, :pay, :deliver, :cancel]
+    def create
+      order = ::Orders::Create.execute(store_uuid: params[:store_uuid], products: order_products_params)
+
+      render json: OrderBlueprint.render(order)
+    end
+
+    def update
+      order = ::Orders::Update.execute(order: @order, products: order_products_params)
+
+      render json: OrderBlueprint.render(order)
+    end
+
+    def show
+      render json: OrderBlueprint.render(@order)
+    end
+
+    # State change actions
+    def pay
+      ::Orders::StateChanges::Pay.execute(order: @order)
+
+      render json: OrderBlueprint.render(@order)
+    end
+
+    def deliver
+      ::Orders::StateChanges::Deliver.execute(order: @order)
+
+      render json: OrderBlueprint.render(@order)
+    end
+
+    def cancel
+      ::Orders::StateChanges::Cancel.execute(order: @order)
+
+      render json: OrderBlueprint.render(@order)
+    end
+
+    private
+
+    def set_order
+      @order = Order.find_by!(uuid: params[:uuid])
+    end
+
+    def order_products_params
+      params.require(:products).map do |product|
+        product.permit(:product_uuid, :quantity)
+      end
+    end
+  end
+end

--- a/app/blueprints/order_blueprint.rb
+++ b/app/blueprints/order_blueprint.rb
@@ -1,0 +1,19 @@
+class OrderBlueprint < Blueprinter::Base
+  identifier :uuid
+  field :total_price do |order|
+    order.total_price.to_f / 100
+  end
+  field :status
+  field :created_at
+
+  field :products do |order|
+    order.products.map do |product|
+      {
+        uuid: product.uuid,
+        name: product.name,
+        price: product.price.to_f / 100,
+        quantity: order.order_products.find_by(product: product).quantity
+      }
+    end
+  end
+end

--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -1,0 +1,41 @@
+class Order < ApplicationRecord
+  include AASM
+  belongs_to :store
+  has_many :order_products, dependent: :destroy
+  has_many :products, through: :order_products
+
+  validates :status, presence: true
+
+  enum status: { draft: 0, paid: 1, delivered: 2, cancelled: 3 }
+
+  aasm column: 'status', enum: true do
+    state :draft, initial: true
+    state :paid
+    state :delivered
+    state :cancelled
+
+    event :pay do
+      transitions from: :draft, to: :paid
+    end
+
+    event :deliver do
+      transitions from: :paid, to: :delivered
+    end
+
+    event :cancel do
+      transitions from: [:draft, :paid], to: :cancelled
+    end
+  end
+
+  before_create :generate_uuid
+
+  private
+
+  def total_price_is_positive?
+    total_price.positive?
+  end
+
+  def generate_uuid
+    self.uuid = SecureRandom.uuid
+  end
+end

--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -23,7 +23,7 @@ class Order < ApplicationRecord
     end
 
     event :cancel do
-      transitions from: [:draft, :paid], to: :cancelled
+      transitions from: :draft, to: :cancelled
     end
   end
 

--- a/app/models/order_product.rb
+++ b/app/models/order_product.rb
@@ -1,0 +1,6 @@
+class OrderProduct < ApplicationRecord
+  belongs_to :order
+  belongs_to :product
+
+  validates :quantity, presence: true, numericality: { greater_than: 0 }
+end

--- a/app/models/order_product.rb
+++ b/app/models/order_product.rb
@@ -3,4 +3,5 @@ class OrderProduct < ApplicationRecord
   belongs_to :product
 
   validates :quantity, presence: true, numericality: { greater_than: 0 }
+  validates :product, uniqueness: { scope: :order }
 end

--- a/app/services/orders/calculate_total_amount.rb
+++ b/app/services/orders/calculate_total_amount.rb
@@ -1,0 +1,19 @@
+module Orders
+  class CalculateTotalAmount < BaseService
+    def initialize(order)
+      @order = order
+    end
+
+    def execute
+      @order.update_attribute(:total_price, calculate_total_amount)
+    end
+
+    private
+
+    def calculate_total_amount
+      @order.order_products.sum do |order_product|
+        order_product.quantity * order_product.product.price
+      end
+    end
+  end
+end

--- a/app/services/orders/create.rb
+++ b/app/services/orders/create.rb
@@ -1,0 +1,31 @@
+module Orders
+  class Create < BaseService
+    def initialize(store_uuid:, products:)
+      @store_uuid = store_uuid
+      @products   = products
+    end
+
+    def execute
+      Order.transaction do
+        store = Store.find_by(uuid: @store_uuid)
+
+        raise ArgumentError, "Tienda no encontrada" if store.nil?
+
+        order = Order.create!(store: store, status: 0)
+
+        @products.each do |product_data|
+          product = Product.find_by(uuid: product_data[:product_uuid])
+          store_product = StoreProduct.find_by(store: store, product: product)
+
+          raise ArgumentError, "Producto no encontrado en la tienda" if store_product.nil?
+
+          OrderProduct.create!(order: order, product: product, quantity: product_data[:quantity])
+        end
+
+        ::Orders::CalculateTotalAmount.execute(order)
+
+        order.reload
+      end
+    end
+  end
+end

--- a/app/services/orders/state_changes/cancel.rb
+++ b/app/services/orders/state_changes/cancel.rb
@@ -1,0 +1,15 @@
+module Orders
+  module StateChanges
+    class Cancel < BaseService
+      def initialize(order:)
+        @order = order
+      end
+
+      def execute
+        Order.transaction do
+          @order.cancel!
+        end
+      end
+    end
+  end
+end

--- a/app/services/orders/state_changes/deliver.rb
+++ b/app/services/orders/state_changes/deliver.rb
@@ -1,0 +1,15 @@
+module Orders
+  module StateChanges
+    class Deliver < BaseService
+      def initialize(order:)
+        @order = order
+      end
+
+      def execute
+        Order.transaction do
+          @order.deliver!
+        end
+      end
+    end
+  end
+end

--- a/app/services/orders/state_changes/pay.rb
+++ b/app/services/orders/state_changes/pay.rb
@@ -1,0 +1,16 @@
+module Orders
+  module StateChanges
+    class Pay < BaseService
+      def initialize(order:)
+        @order = order
+      end
+
+      def execute
+        Order.transaction do
+          @order.pay!
+        end
+        # Aqui se enviaría el correo
+      end
+    end
+  end
+end

--- a/app/services/orders/update.rb
+++ b/app/services/orders/update.rb
@@ -1,0 +1,30 @@
+module Orders
+  class Update < BaseService
+    def initialize(order:, products:)
+      @order = order
+      @products = products
+    end
+
+    def execute
+      Order.transaction do
+        raise ArgumentError, "No se puede actualizar un pedido pagado o entregado" if @order.paid? || @order.delivered? || @order.cancelled?
+
+        OrderProduct.where(order: @order).destroy_all
+
+        @products.each do |product_data|
+          product = Product.find_by(uuid: product_data[:product_uuid])
+
+          store_product = StoreProduct.find_by(store: @order.store, product: product)
+
+          raise ArgumentError, "Producto no encontrado en la tienda" if store_product.nil?
+
+          OrderProduct.create!(order: @order, product: product, quantity: product_data[:quantity])
+        end
+
+        ::Orders::CalculateTotalAmount.execute(@order)
+
+        @order.reload
+      end
+    end
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -23,6 +23,13 @@ Rails.application.routes.draw do
       namespace :selects do
         get :product_kinds
       end
+      resources :orders, param: :uuid, only: [:create, :update, :show] do
+        member do
+          post :pay
+          post :deliver
+          post :cancel
+        end
+      end
     end
   end
 end

--- a/db/migrate/20250219224936_create_orders.rb
+++ b/db/migrate/20250219224936_create_orders.rb
@@ -1,0 +1,20 @@
+class CreateOrders < ActiveRecord::Migration[7.2]
+  def change
+    create_table :orders do |t|
+      t.string :uuid, null: false
+      t.references :store, null: false, foreign_key: true
+      t.integer :total_price, null: true
+      t.integer :status, null: false, default: 0
+
+      t.timestamps
+    end
+
+    create_table :order_products do |t|
+      t.references :order, null: false, foreign_key: true
+      t.references :product, null: false, foreign_key: true
+      t.integer :quantity, null: false
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_02_19_213132) do
+ActiveRecord::Schema[7.2].define(version: 2025_02_19_224936) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -24,6 +24,26 @@ ActiveRecord::Schema[7.2].define(version: 2025_02_19_213132) do
     t.string "city", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+  end
+
+  create_table "order_products", force: :cascade do |t|
+    t.bigint "order_id", null: false
+    t.bigint "product_id", null: false
+    t.integer "quantity", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["order_id"], name: "index_order_products_on_order_id"
+    t.index ["product_id"], name: "index_order_products_on_product_id"
+  end
+
+  create_table "orders", force: :cascade do |t|
+    t.string "uuid", null: false
+    t.bigint "store_id", null: false
+    t.integer "total_price"
+    t.integer "status", default: 0, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["store_id"], name: "index_orders_on_store_id"
   end
 
   create_table "products", force: :cascade do |t|
@@ -57,6 +77,9 @@ ActiveRecord::Schema[7.2].define(version: 2025_02_19_213132) do
     t.index ["address_id"], name: "index_stores_on_address_id"
   end
 
+  add_foreign_key "order_products", "orders"
+  add_foreign_key "order_products", "products"
+  add_foreign_key "orders", "stores"
   add_foreign_key "store_products", "products"
   add_foreign_key "store_products", "stores"
 end

--- a/docs/dev/commands.md
+++ b/docs/dev/commands.md
@@ -50,4 +50,4 @@
 
 - Run rspec without swagger documentation
 
-` bundle exec rspec --exclude-pattern "spec/requests/**/*_spec.rb"`
+`bundle exec rspec --exclude-pattern "spec/requests/**/*_spec.rb"`

--- a/spec/controllers/api/v1/orders_controller_spec.rb
+++ b/spec/controllers/api/v1/orders_controller_spec.rb
@@ -1,0 +1,137 @@
+require 'rails_helper'
+
+RSpec.describe V1::OrdersController, type: :controller do
+  describe 'GET #show' do
+    let(:store) { create(:store) }
+    let(:order) { create(:order, store: store) }
+
+    it 'returns the requested order' do
+      get :show, params: { uuid: order.uuid }
+      expect(response).to have_http_status(:ok)
+      expect(JSON.parse(response.body)['uuid']).to eq(order.uuid)
+    end
+  end
+
+  describe 'POST #create' do
+    let(:store) { create(:store) }
+    let(:product) { create(:product) }
+    let!(:store_product) { create(:store_product, store: store, product: product) }
+    let(:valid_params) do
+      {
+        "store_uuid": store.uuid,
+        "products": [
+          {
+            "product_uuid": product.uuid,
+            "quantity": 2
+          }
+        ]
+      }
+    end
+
+    it 'creates a new order successfully' do
+      expect {
+        post :create, params: valid_params
+      }.to change(Order, :count).by(1)
+      
+      expect(response).to have_http_status(:success)
+      expect(JSON.parse(response.body)['total_price']).to eq((product.price.to_f * 2) / 100)
+      expect(JSON.parse(response.body)['status']).to eq('draft')
+    end
+
+    it 'returns an error when the product is not found' do
+      expect {
+        post :create, params: { store_uuid: store.uuid, products: [{ product_uuid: 'non_existent_uuid', quantity: 2 }] }
+      }.not_to change(Order, :count)
+      
+      expect(response).to have_http_status(:unprocessable_entity) 
+    end
+
+    it 'returns an error when the store is not found' do
+      expect {
+        post :create, params: { store_uuid: 'non_existent_uuid', products: [{ product_uuid: product.uuid, quantity: 2 }] }
+      }.not_to change(Order, :count)
+      
+      expect(response).to have_http_status(:unprocessable_entity)
+    end 
+  end
+
+  describe 'PATCH #update' do
+    let(:store) { create(:store) }
+    let(:product) { create(:product) }
+    let!(:store_product) { create(:store_product, store: store, product: product) }
+    let(:order) { create(:order, store: store) }
+
+    it 'updates order total_amount' do
+      patch :update, params: { uuid: order.uuid, products: [{ product_uuid: product.uuid, quantity: 2 }] }
+      
+      expect(response).to have_http_status(:ok)
+      expect(JSON.parse(response.body)['total_price']).to eq((product.price.to_f * 2) / 100)
+    end
+
+    it 'returns an error when the product is not found' do
+      patch :update, params: { uuid: order.uuid, products: [{ product_uuid: 'non_existent_uuid', quantity: 2 }] }
+      
+      expect(response).to have_http_status(:unprocessable_entity)
+    end 
+
+    it 'returns an error when the store is not found' do
+      patch :update, params: { uuid: 'non_existent_uuid', products: [{ product_uuid: product.uuid, quantity: 2 }] }
+      
+      expect(response).to have_http_status(:not_found)
+    end
+  end
+
+  describe 'State machine transitions' do
+    describe 'POST #pay' do
+      let(:order) { create(:order) }
+
+      it 'changes order state from pending to paid' do
+        post :pay, params: { uuid: order.uuid }
+        
+        expect(response).to have_http_status(:ok)
+        order.reload
+        expect(order.status).to eq('paid')
+      end
+
+      it 'fails when trying to pay an already paid order' do
+        order.update(status: 'paid')
+        post :pay, params: { uuid: order.uuid }
+        
+        expect(response).to have_http_status(:unprocessable_entity)
+      end
+
+      it 'fails when trying to pay a cancelled order' do
+        order.update(status: 'cancelled')
+        post :pay, params: { uuid: order.uuid }
+        
+        expect(response).to have_http_status(:unprocessable_entity)
+      end
+    end
+
+    describe 'POST #cancel' do
+      let(:order) { create(:order) }
+
+      it 'changes order state from pending to cancelled' do
+        post :cancel, params: { uuid: order.uuid }
+        
+        expect(response).to have_http_status(:ok)
+        order.reload
+        expect(order.status).to eq('cancelled')
+      end
+
+      it 'fails when trying to cancel a paid order' do
+        order.update(status: 'paid')
+        post :cancel, params: { uuid: order.uuid }
+        
+        expect(response).to have_http_status(:unprocessable_entity)
+      end
+
+      it 'fails when trying to cancel an already cancelled order' do
+        order.update(status: 'cancelled')
+        post :cancel, params: { uuid: order.uuid }
+        
+        expect(response).to have_http_status(:unprocessable_entity)
+      end
+    end
+  end
+end

--- a/spec/factories/order_products.rb
+++ b/spec/factories/order_products.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :order_product do
+    order
+    product
+  end
+end

--- a/spec/factories/orders.rb
+++ b/spec/factories/orders.rb
@@ -1,0 +1,15 @@
+FactoryBot.define do
+  factory :order do
+    status { 0 }
+    total_price { 1000 }
+    store
+    
+    trait :paid do
+      status { 1 }
+    end
+
+    trait :cancelled do
+      status { 3 }
+    end
+  end
+end 

--- a/spec/factories/store_products.rb
+++ b/spec/factories/store_products.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :store_product do
+    store
+    product
+  end
+end

--- a/spec/models/order_product_spec.rb
+++ b/spec/models/order_product_spec.rb
@@ -1,0 +1,35 @@
+require 'rails_helper'
+
+RSpec.describe OrderProduct, type: :model do
+  describe 'associations' do
+    it { should belong_to(:order) }
+    it { should belong_to(:product) }
+  end
+
+  describe 'validations' do
+    it { should validate_presence_of(:quantity) }
+  end
+
+  describe 'callbacks' do
+    let(:store) { create(:store) }
+    let(:product) { create(:product, price: 1000) }
+    let(:order) { create(:order, store: store) }
+
+    before do
+      create(:store_product, store: store, product: product)
+    end
+
+    it 'updates order total_price after creation' do
+      order_product = create(:order_product, order: order, product: product, quantity: 2)
+      ::Orders::CalculateTotalAmount.execute(order)
+      expect(order.reload.total_price).to eq(product.price * 2)
+    end
+
+    it 'updates order total_price after updating quantity' do
+      order_product = create(:order_product, order: order, product: product, quantity: 2)
+      order_product.update(quantity: 3)
+      ::Orders::CalculateTotalAmount.execute(order)
+      expect(order.reload.total_price).to eq(product.price * 3)
+    end
+  end
+end 

--- a/spec/models/order_spec.rb
+++ b/spec/models/order_spec.rb
@@ -1,0 +1,59 @@
+require 'rails_helper'
+
+RSpec.describe Order, type: :model do
+  describe 'associations' do
+    it { should belong_to(:store) }
+    it { should have_many(:order_products).dependent(:destroy) }
+    it { should have_many(:products).through(:order_products) }
+  end
+
+  describe 'validations' do
+    it { should validate_presence_of(:status) }
+  end
+
+  describe 'enums' do
+    it { should define_enum_for(:status).with_values(draft: 0, paid: 1, delivered: 2, cancelled: 3) }
+  end
+
+  describe 'callbacks' do
+    it 'generates uuid before creation' do
+      order = build(:order, uuid: nil)
+      order.save
+      expect(order.uuid).not_to be_nil
+    end
+  end
+
+  describe 'state transitions' do
+    let(:order) { create(:order, status: :draft) }
+
+    describe '#pay' do
+      it 'transitions from draft to paid' do
+        expect(order.pay!).to be true
+        expect(order.reload.status).to eq('paid')
+      end
+    end
+
+    describe '#cancel' do
+      it 'transitions from draft to cancelled' do
+        expect(order.cancel!).to be true
+        expect(order.reload.status).to eq('cancelled')
+      end
+    end
+  end
+
+  describe '#calculate_total_amount' do
+    let(:store) { create(:store) }
+    let(:product) { create(:product, price: 1000) }
+    let(:order) { create(:order, store: store) }
+
+    before do
+      create(:store_product, store: store, product: product)
+      create(:order_product, order: order, product: product, quantity: 2)
+    end
+
+    it 'calculates the total amount correctly' do
+      ::Orders::CalculateTotalAmount.execute(order)
+      expect(order.total_price).to eq(2000)
+    end
+  end
+end 

--- a/spec/requests/api/v1/orders_spec.rb
+++ b/spec/requests/api/v1/orders_spec.rb
@@ -1,0 +1,274 @@
+require 'swagger_helper'
+
+RSpec.describe 'api/v1/orders', type: :request do
+  path '/api/v1/orders' do
+    post 'Create an order' do
+      tags 'Orders'
+      description 'Create an order'
+      operationId 'createOrder'
+      consumes 'application/json'
+      produces 'application/json'
+      parameter name: :order, in: :body, required: true,
+                schema: { '$ref' => '#/components/schemas/create_order' }
+
+      response(200, 'successful') do
+        schema '$ref' => '#/components/schemas/order'
+        after do |example|
+          example.metadata[:response][:content] = {
+            'application/json' => {
+              example: JSON.parse(response.body, symbolize_names: true)
+            }
+          }
+        end
+        run_test!
+      end
+
+      response(422, 'invalid request') do
+        schema '$ref' => '#/components/schemas/generic_error'
+        after do |example|
+          example.metadata[:response][:content] = {
+            'application/json' => {
+              example: JSON.parse(response.body, symbolize_names: true)
+            }
+          }
+        end
+        run_test!
+      end
+
+      response(404, 'not found') do
+        schema '$ref' => '#/components/schemas/generic_error'
+        run_test!
+      end
+    end
+  end
+
+  path '/api/v1/orders/{uuid}' do
+    parameter name: :uuid, in: :path, required: true, type: :string
+
+    get 'Show an order' do
+      tags 'Orders'
+      description 'Show an order' 
+      operationId 'showOrder'
+      consumes 'application/json'
+      produces 'application/json'
+
+      response(200, 'successful') do
+        schema '$ref' => '#/components/schemas/order'
+        after do |example|
+          example.metadata[:response][:content] = {
+            'application/json' => {
+              example: JSON.parse(response.body, symbolize_names: true)
+            }
+          } 
+        end
+        run_test! 
+      end
+
+      response(404, 'not found') do
+        schema '$ref' => '#/components/schemas/generic_error'
+        after do |example|
+          example.metadata[:response][:content] = {
+            'application/json' => {
+              example: JSON.parse(response.body, symbolize_names: true)
+            }
+          }
+        end 
+        run_test!
+      end 
+    end
+
+    path '/api/v1/orders/{uuid}' do
+      parameter name: :uuid, in: :path, required: true, type: :string
+
+      put 'Update an order' do
+        tags 'Orders'
+        description 'Update an order'
+        operationId 'updateOrder'
+        consumes 'application/json'
+        produces 'application/json'
+        parameter name: :order, in: :body, required: true,
+                schema: { '$ref' => '#/components/schemas/update_order' }
+
+        response(200, 'successful') do
+          schema '$ref' => '#/components/schemas/order'
+          after do |example|
+            example.metadata[:response][:content] = {
+              'application/json' => {
+                example: JSON.parse(response.body, symbolize_names: true)
+              }
+            }
+          end 
+          run_test!
+        end
+
+        response(422, 'invalid request') do
+          schema '$ref' => '#/components/schemas/generic_error'
+          after do |example|
+            example.metadata[:response][:content] = {
+              'application/json' => {
+                example: JSON.parse(response.body, symbolize_names: true)
+              }
+            }
+          end  
+          run_test!
+        end 
+
+        response(404, 'not found') do
+          schema '$ref' => '#/components/schemas/generic_error'
+          after do |example|
+            example.metadata[:response][:content] = {
+              'application/json' => {
+                example: JSON.parse(response.body, symbolize_names: true)
+              } 
+            }
+            run_test!
+          end
+        end 
+      end
+    end
+  end
+
+  path '/api/v1/orders/{uuid}/pay' do
+    parameter name: :uuid, in: :path, required: true, type: :string
+
+    post 'Pay an order' do
+      tags 'Orders'
+      description 'Pay an order'  
+      operationId 'payOrder'
+      consumes 'application/json'
+      produces 'application/json'
+
+      response(200, 'successful') do
+        schema '$ref' => '#/components/schemas/order'
+        after do |example|
+          example.metadata[:response][:content] = {
+            'application/json' => {
+              example: JSON.parse(response.body, symbolize_names: true)
+            } 
+          }
+        end
+        run_test!
+      end
+
+      response(422, 'invalid request') do
+        schema '$ref' => '#/components/schemas/generic_error'
+        after do |example|
+          example.metadata[:response][:content] = {
+            'application/json' => {
+              example: JSON.parse(response.body, symbolize_names: true)
+            }
+          }
+        end 
+        run_test!
+      end
+
+      response(404, 'not found') do
+        schema '$ref' => '#/components/schemas/generic_error'
+        after do |example|
+          example.metadata[:response][:content] = {
+            'application/json' => {
+              example: JSON.parse(response.body, symbolize_names: true)
+            }
+          }
+        end
+        run_test!
+      end
+    end
+  end
+
+  path '/api/v1/orders/{uuid}/cancel' do
+    parameter name: :uuid, in: :path, required: true, type: :string
+
+    post 'Cancel an order' do
+      tags 'Orders'
+      description 'Cancel an order' 
+      operationId 'cancelOrder'
+      consumes 'application/json'
+      produces 'application/json'
+
+      response(200, 'successful') do
+        schema '$ref' => '#/components/schemas/order'
+        after do |example|
+          example.metadata[:response][:content] = {
+            'application/json' => {
+              example: JSON.parse(response.body, symbolize_names: true)
+            }
+          } 
+        end
+        run_test!
+      end
+
+      response(422, 'invalid request') do
+        schema '$ref' => '#/components/schemas/generic_error'
+        after do |example|
+          example.metadata[:response][:content] = {
+            'application/json' => {
+              example: JSON.parse(response.body, symbolize_names: true) 
+            }
+          }
+        end
+        run_test!
+      end
+
+      response(404, 'not found') do
+        schema '$ref' => '#/components/schemas/generic_error'
+        after do |example|
+          example.metadata[:response][:content] = {
+            'application/json' => {
+              example: JSON.parse(response.body, symbolize_names: true)
+            }
+          }
+          run_test!
+        end
+      end
+    end
+  end
+
+  path '/api/v1/orders/{uuid}/deliver' do
+    parameter name: :uuid, in: :path, required: true, type: :string
+
+    post 'Deliver an order' do
+      tags 'Orders'
+      description 'Deliver an order'  
+      operationId 'deliverOrder'
+      consumes 'application/json'
+      produces 'application/json'
+
+      response(200, 'successful') do
+        schema '$ref' => '#/components/schemas/order'
+        after do |example|
+          example.metadata[:response][:content] = {
+            'application/json' => {
+              example: JSON.parse(response.body, symbolize_names: true)
+            }
+          } 
+        end
+        run_test!
+      end
+
+      response(422, 'invalid request') do
+        schema '$ref' => '#/components/schemas/generic_error'
+        after do |example|
+          example.metadata[:response][:content] = {
+            'application/json' => {
+              example: JSON.parse(response.body, symbolize_names: true) 
+            }
+          }
+          run_test!
+        end
+      end 
+
+      response(404, 'not found') do
+        schema '$ref' => '#/components/schemas/generic_error'
+        after do |example|
+          example.metadata[:response][:content] = {
+            'application/json' => { 
+              example: JSON.parse(response.body, symbolize_names: true)
+            }
+          }
+          run_test!
+        end
+      end 
+    end
+  end
+end

--- a/spec/schemas/order.yml
+++ b/spec/schemas/order.yml
@@ -1,0 +1,63 @@
+create_order:
+  type: object
+  properties:
+    store_uuid:
+      type: string
+      example: 'UUID of the store'
+    products:
+      type: array
+      items:
+        type: object
+        properties:
+          product_uuid:
+            type: string
+            example: 'UUID of the product'
+          quantity:
+            type: integer
+            example: 'Quantity of the product'
+update_order:
+  type: object
+  properties:
+    products:
+      type: array
+      items:
+        type: object
+        properties:
+          product_uuid:
+            type: string
+            example: 'UUID of the product'
+          quantity:
+            type: integer
+            example: 'Quantity of the product'
+order:
+  type: object
+  properties:
+    uuid:
+      type: string
+      example: 'UUID of the order'
+    total_price:
+      type: number
+      example: 'Total price of the order'
+    status:
+      type: string
+      example: 'Status of the order'  
+    created_at:
+      type: datetime
+      example: 'Created at of the order'
+    products:
+      type: array
+      items:
+        type: object
+        properties:
+          uuid:
+            type: string
+            example: 'UUID of the product'
+          name:
+            type: string
+            example: 'Name of the product'
+          price:
+            type: number
+            example: 'Price of the product'
+          quantity:
+            type: integer
+            example: 'Quantity of the product'

--- a/spec/swagger_helper.rb
+++ b/spec/swagger_helper.rb
@@ -5,6 +5,7 @@ require 'rails_helper'
 store_schema = YAML.load_file(Rails.root.join('spec/schemas/store.yml'))
 generic_error_schema = YAML.load_file(Rails.root.join('spec/schemas/generic_error.yml'))
 product_schema = YAML.load_file(Rails.root.join('spec/schemas/product.yml'))
+order_schema = YAML.load_file(Rails.root.join('spec/schemas/order.yml'))
 
 RSpec.configure do |config|
   # Specify a root folder where Swagger JSON files are generated
@@ -34,7 +35,10 @@ RSpec.configure do |config|
           products: product_schema.dig('products'),
           create_product: product_schema.dig('create_product'),
           product: product_schema.dig('product'),
-          assign_products: store_schema.dig('assign_products')
+          assign_products: store_schema.dig('assign_products'),
+          update_order: order_schema.dig('update_order'),
+          order: order_schema.dig('order'),
+          create_order: order_schema.dig('create_order')
         }
       },
       paths: {},

--- a/swagger/v1/swagger.yaml
+++ b/swagger/v1/swagger.yaml
@@ -207,7 +207,233 @@ components:
           type: string
           example: Product_uuid1,Product_uuid2,Product_uuid3
           description: Product uuids to assign separated by commas
+    update_order:
+      type: object
+      properties:
+        products:
+          type: array
+          items:
+            type: object
+            properties:
+              product_uuid:
+                type: string
+                example: UUID of the product
+              quantity:
+                type: integer
+                example: Quantity of the product
+    order:
+      type: object
+      properties:
+        uuid:
+          type: string
+          example: UUID of the order
+        total_price:
+          type: number
+          example: Total price of the order
+        status:
+          type: string
+          example: Status of the order
+        created_at:
+          type: datetime
+          example: Created at of the order
+        products:
+          type: array
+          items:
+            type: object
+            properties:
+              uuid:
+                type: string
+                example: UUID of the product
+              name:
+                type: string
+                example: Name of the product
+              price:
+                type: number
+                example: Price of the product
+              quantity:
+                type: integer
+                example: Quantity of the product
+    create_order:
+      type: object
+      properties:
+        store_uuid:
+          type: string
+          example: UUID of the store
+        products:
+          type: array
+          items:
+            type: object
+            properties:
+              product_uuid:
+                type: string
+                example: UUID of the product
+              quantity:
+                type: integer
+                example: Quantity of the product
 paths:
+  "/api/v1/orders":
+    post:
+      summary: Create an order
+      tags:
+      - Orders
+      description: Create an order
+      operationId: createOrder
+      parameters: []
+      responses:
+        '200':
+          description: successful
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/order"
+        '422':
+          description: invalid request
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/generic_error"
+        '404':
+          description: not found
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/generic_error"
+      requestBody:
+        content:
+          application/json:
+            schema:
+              "$ref": "#/components/schemas/create_order"
+        required: true
+  "/api/v1/orders/{uuid}":
+    parameters:
+    - name: uuid
+      in: path
+      required: true
+      schema:
+        type: string
+    get:
+      summary: Show an order
+      tags:
+      - Orders
+      description: Show an order
+      operationId: showOrder
+      responses:
+        '200':
+          description: successful
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/order"
+        '404':
+          description: not found
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/generic_error"
+    put:
+      summary: Update an order
+      tags:
+      - Orders
+      description: Update an order
+      operationId: updateOrder
+      parameters: []
+      responses:
+        '200':
+          description: successful
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/order"
+        '422':
+          description: invalid request
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/generic_error"
+      requestBody:
+        content:
+          application/json:
+            schema:
+              "$ref": "#/components/schemas/update_order"
+        required: true
+  "/api/v1/orders/{uuid}/pay":
+    parameters:
+    - name: uuid
+      in: path
+      required: true
+      schema:
+        type: string
+    post:
+      summary: Pay an order
+      tags:
+      - Orders
+      description: Pay an order
+      operationId: payOrder
+      responses:
+        '200':
+          description: successful
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/order"
+        '422':
+          description: invalid request
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/generic_error"
+        '404':
+          description: not found
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/generic_error"
+  "/api/v1/orders/{uuid}/cancel":
+    parameters:
+    - name: uuid
+      in: path
+      required: true
+      schema:
+        type: string
+    post:
+      summary: Cancel an order
+      tags:
+      - Orders
+      description: Cancel an order
+      operationId: cancelOrder
+      responses:
+        '200':
+          description: successful
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/order"
+        '422':
+          description: invalid request
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/generic_error"
+  "/api/v1/orders/{uuid}/deliver":
+    parameters:
+    - name: uuid
+      in: path
+      required: true
+      schema:
+        type: string
+    post:
+      summary: Deliver an order
+      tags:
+      - Orders
+      description: Deliver an order
+      operationId: deliverOrder
+      responses:
+        '200':
+          description: successful
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/order"
   "/api/v1/products":
     get:
       summary: show products


### PR DESCRIPTION
In this feature, we implemented the following points:

- Created the migration and models for orders and the connection between orders and products  
- Creation, update, and detail view of a product  
- Added the AASM gem to handle order state changes  
- Added endpoints for state changes (pay, deliver, cancel)  
- Added tests (Rspec)  
- Added Swagger documentation  
